### PR TITLE
fix(ego_planner): improve planning logic for sparse maps and obstacle…

### DIFF
--- a/opendrone/launch/sitl_ego_planner.launch
+++ b/opendrone/launch/sitl_ego_planner.launch
@@ -17,7 +17,7 @@
         <arg name="odom_topic" value="/mavros/local_position/odom"/>
         <arg name="max_vel" value="1.0" />
         <arg name="max_acc" value="2.0" />
-        <arg name="obstacles_inflation" value="0.25" />
+        <!-- <arg name="obstacles_inflation" value="0.25" /> -->
         <!-- <arg name="debug_map" default="false"/>
         <arg name="debug_fsm" default="false"/>
         <arg name="debug_planner" default="false"/>

--- a/opendrone/launch/sitl_ego_planner_mid360.launch
+++ b/opendrone/launch/sitl_ego_planner_mid360.launch
@@ -12,7 +12,7 @@
         <param name="cloud_timeout" value="1.0" />
         <param name="log_interval" value="2.0" />
         <!-- filter -->
-        <param name="filter_enable" value="true" />
+        <param name="filter_enable" value="false" />
         <param name="voxel_leaf_size" value="0.1" />
         <param name="min_range" value="0.1" />
         <param name="max_range" value="50.0" />
@@ -34,7 +34,7 @@
         <arg name="p_occ" value="0.65" />
         <arg name="p_hit" value="0.75" />
         <arg name="max_ray_length" value="12.0" />
-        <arg name="obstacles_inflation" value="0.25" />
+        <arg name="obstacles_inflation" value="0.15" />
         <arg name="ground_height" value="-0.3" />
         <!-- <arg name="debug_map" default="false"/>
         <arg name="debug_fsm" default="false"/>

--- a/opendrone/scripts/pointcloud_to_world.py
+++ b/opendrone/scripts/pointcloud_to_world.py
@@ -131,10 +131,12 @@ class PointCloudToWorld:
         range_count = initial_count
         if self.min_range is not None or self.max_range is not None:
             ranges = np.linalg.norm(points, axis=1)
+            range_mask = np.ones(points.shape[0], dtype=bool)
             if self.min_range is not None:
-                points = points[ranges >= float(self.min_range)]
+                range_mask &= (ranges >= float(self.min_range))
             if self.max_range is not None:
-                points = points[ranges <= float(self.max_range)]
+                range_mask &= (ranges <= float(self.max_range))
+            points = points[range_mask]
             range_count = points.shape[0]
 
         if points.size == 0:

--- a/opendrone/sitl_config/outdoor_mid360.launch
+++ b/opendrone/sitl_config/outdoor_mid360.launch
@@ -21,9 +21,6 @@
     <arg name="verbose" default="false"/>
     <arg name="paused" default="false"/>
     <arg name="respawn_gazebo" default="false"/>
-    <!-- MAVROS configs -->
-    <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
-    <arg name="respawn_mavros" default="false"/>
     <!-- PX4 configs -->
     <arg name="interactive" default="true"/>
     <!-- PX4 SITL and Gazebo -->

--- a/planner/ego_planner_swarm/bspline_opt/include/bspline_opt/bspline_optimizer.h
+++ b/planner/ego_planner_swarm/bspline_opt/include/bspline_opt/bspline_optimizer.h
@@ -125,6 +125,7 @@ namespace ego_planner
 
     inline int getOrder(void) { return order_; }
     inline double getSwarmClearance(void) { return swarm_clearance_; }
+    inline bool isTerminalInObstacleAbort(void) const { return terminal_in_obstacle_abort_; }
 
   private:
     GridMap::Ptr grid_map_;
@@ -171,6 +172,8 @@ namespace ego_planner
     double min_cost_;               //
 
     Eigen::Vector3d local_target_pt_; 
+
+    bool terminal_in_obstacle_abort_{false};
 
 #define INIT_min_ellip_dist_ 123456789.0123456789
     double min_ellip_dist_;

--- a/planner/ego_planner_swarm/bspline_opt/src/bspline_optimizer.cpp
+++ b/planner/ego_planner_swarm/bspline_opt/src/bspline_optimizer.cpp
@@ -1256,71 +1256,10 @@ namespace ego_planner
         }
         if (j >= cps_.size) // fail to get the obs free point
         {
-          ROS_WARN_THROTTLE(1.0, "WARN! terminal point of the current trajectory is in obstacle, try tail fallback.");
-
-          Eigen::Vector3d anchor = cps_.points.col(in_id);
-          Eigen::Vector3d prefer_dir = anchor - local_target_pt_;
-          if (prefer_dir.norm() < 1e-3)
-            prefer_dir = Eigen::Vector3d::UnitX();
-          else
-            prefer_dir.normalize();
-
-          Eigen::Vector3d side_dir = prefer_dir.cross(Eigen::Vector3d::UnitZ());
-          if (side_dir.norm() < 1e-3)
-            side_dir = Eigen::Vector3d::UnitY();
-          else
-            side_dir.normalize();
-
-          std::vector<Eigen::Vector3d> dirs;
-          dirs.reserve(6);
-          dirs.push_back(prefer_dir);
-          dirs.push_back(-prefer_dir);
-          dirs.push_back(side_dir);
-          dirs.push_back(-side_dir);
-          dirs.push_back(Eigen::Vector3d::UnitZ());
-          dirs.push_back(-Eigen::Vector3d::UnitZ());
-
-          const double step = std::max(0.2, grid_map_->getResolution() * 2.0);
-          bool found_free = false;
-          Eigen::Vector3d fallback_pt = anchor;
-          for (int r = 1; r <= 12 && !found_free; ++r)
-          {
-            for (const auto &d : dirs)
-            {
-              Eigen::Vector3d cand = anchor + d * step * r;
-              if (!grid_map_->isInMap(cand))
-                continue;
-              if (!grid_map_->getInflateOccupancy(cand))
-              {
-                fallback_pt = cand;
-                found_free = true;
-                break;
-              }
-            }
-          }
-
-          if (!found_free)
-          {
-            ROS_WARN_THROTTLE(1.0, "WARN! terminal in obstacle and fallback failed, skip this planning.");
-            force_stop_type_ = STOP_FOR_ERROR;
-            return false;
-          }
-
-          out_id = std::min(cps_.size - 1, in_id + 1);
-          if (out_id <= in_id)
-          {
-            ROS_WARN_THROTTLE(1.0, "WARN! fallback out_id invalid, skip this planning.");
-            force_stop_type_ = STOP_FOR_ERROR;
-            return false;
-          }
-
-          cps_.points.col(out_id) = fallback_pt;
-          for (int k = out_id + 1; k < cps_.size; ++k)
-            cps_.points.col(k) = fallback_pt;
-
-          ROS_WARN_THROTTLE(1.0,
-                            "WARN! terminal in obstacle, fallback tail point to (%.2f, %.2f, %.2f)",
-                            fallback_pt.x(), fallback_pt.y(), fallback_pt.z());
+          ROS_WARN_THROTTLE(1.0, "WARN! terminal point of the current trajectory is in obstacle, skip this planning.");
+          terminal_in_obstacle_abort_ = true;
+          force_stop_type_ = STOP_FOR_ERROR;
+          return false;
         }
 
         i = j + 1;
@@ -1493,6 +1432,7 @@ namespace ego_planner
 
   bool BsplineOptimizer::rebound_optimize(double &final_cost)
   {
+    terminal_in_obstacle_abort_ = false;
     iter_num_ = 0;
     int start_id = order_;
     // int end_id = this->cps_.size - order_; //Fixed end

--- a/planner/ego_planner_swarm/plan_env/include/plan_env/grid_map.h
+++ b/planner/ego_planner_swarm/plan_env/include/plan_env/grid_map.h
@@ -182,6 +182,7 @@ public:
   void publishDepth();
 
   bool hasDepthObservation();
+  bool hasCloudObservation() const { return md_.has_cloud_; }
   bool odomValid();
   void getRegion(Eigen::Vector3d& ori, Eigen::Vector3d& size);
   inline double getResolution();

--- a/planner/ego_planner_swarm/plan_env/src/grid_map.cpp
+++ b/planner/ego_planner_swarm/plan_env/src/grid_map.cpp
@@ -688,7 +688,7 @@ void GridMap::clearAndInflateLocalMap()
           ++inflated_voxels;
       }
   md_.last_inflated_voxels_ = inflated_voxels;
-  ROS_INFO_THROTTLE(1.0, "[grid_map] local inflated voxels: %d", inflated_voxels);
+  ROS_INFO_THROTTLE(3.0, "[grid_map] local inflated voxels: %d", inflated_voxels);
 
   // add virtual ceiling to limit flight height
   if (mp_.virtual_ceil_height_ > -0.5) {
@@ -1073,6 +1073,8 @@ void GridMap::depthOdomCallback(const sensor_msgs::ImageConstPtr &img,
 void GridMap::cloudOdomCallback(const sensor_msgs::PointCloud2ConstPtr &cloud,
                                   const nav_msgs::OdometryConstPtr &odom)
   {
+    md_.has_cloud_ = true;
+
     /* get pose */
     Eigen::Quaterniond body_q = Eigen::Quaterniond(odom->pose.pose.orientation.w,
                                                    odom->pose.pose.orientation.x,
@@ -1141,5 +1143,5 @@ void GridMap::cloudOdomCallback(const sensor_msgs::PointCloud2ConstPtr &cloud,
     }
     // ROS_INFO_STREAM("Grid_map cb"<<"receive "<<md_.proj_points_cnt<<"points");
     md_.occ_need_update_ = true;
-    md_.flag_use_depth_fusion = true;
+    // md_.flag_use_depth_fusion = true;
   }

--- a/planner/ego_planner_swarm/plan_manage/include/plan_manage/planner_manager.h
+++ b/planner/ego_planner_swarm/plan_manage/include/plan_manage/planner_manager.h
@@ -43,6 +43,7 @@ namespace ego_planner
     void setDroneIdtoOpt(void) { bspline_optimizer_->setDroneId(pp_.drone_id); }
 
     double getSwarmClearance(void) { return bspline_optimizer_->getSwarmClearance(); }
+    bool isLastReplanFailedForTerminalInObstacle(void) const { return last_replan_terminal_in_obstacle_; }
 
     bool checkCollision(int drone_id);
     
@@ -63,6 +64,7 @@ namespace ego_planner
     BsplineOptimizer::Ptr bspline_optimizer_;
 
     int continous_failures_count_{0};
+    bool last_replan_terminal_in_obstacle_{false};
 
   bool debug_planner_{false};
   double debug_planner_interval_{1.0};

--- a/planner/ego_planner_swarm/plan_manage/src/ego_replan_fsm.cpp
+++ b/planner/ego_planner_swarm/plan_manage/src/ego_replan_fsm.cpp
@@ -562,7 +562,17 @@ namespace ego_planner
           else
           {
             ROS_ERROR("Failed to generate the first trajectory!!!");
-            changeFSMExecState(SEQUENTIAL_START, "FSM");
+            if (planner_manager_->isLastReplanFailedForTerminalInObstacle())
+            {
+              ROS_WARN("Target is in obstacle, skip planning and wait for a new valid target.");
+              have_target_ = false;
+              have_new_target_ = false;
+              changeFSMExecState(WAIT_TARGET, "FSM");
+            }
+            else
+            {
+              changeFSMExecState(SEQUENTIAL_START, "FSM");
+            }
           }
         }
         else
@@ -592,7 +602,17 @@ namespace ego_planner
       }
       else
       {
-        changeFSMExecState(GEN_NEW_TRAJ, "FSM");
+        if (planner_manager_->isLastReplanFailedForTerminalInObstacle())
+        {
+          ROS_WARN("Target is in obstacle, skip planning and wait for a new valid target.");
+          have_target_ = false;
+          have_new_target_ = false;
+          changeFSMExecState(WAIT_TARGET, "FSM");
+        }
+        else
+        {
+          changeFSMExecState(GEN_NEW_TRAJ, "FSM");
+        }
       }
       break;
     }
@@ -607,6 +627,15 @@ namespace ego_planner
       }
       else
       {
+        if (planner_manager_->isLastReplanFailedForTerminalInObstacle())
+        {
+          ROS_WARN("Target is in obstacle, skip planning and wait for a new valid target.");
+          have_target_ = false;
+          have_new_target_ = false;
+          changeFSMExecState(WAIT_TARGET, "FSM");
+          break;
+        }
+
         const int replan_fail_times = timesOfConsecutiveStateCalls().first;
         bool recovered_by_global = false;
         bool recovered_by_escape = false;
@@ -734,9 +763,12 @@ namespace ego_planner
     const int inflated = map->getLastInflatedVoxelCount();
     const size_t cloud_pts = map->getLastCloudPointCount();
     const bool has_depth = map->hasDepthObservation();
+    const bool has_cloud_obs = map->hasCloudObservation();
     const bool cloud_ready = static_cast<int>(cloud_pts) >= map_ready_min_cloud_;
     const bool depth_ready = has_depth;
-    const bool ready_now = inflated >= map_ready_min_inflated_ && (cloud_ready || depth_ready);
+    // Do not block planning by inflated-voxel count.
+    // As long as either depth stream or pointcloud stream is observed, map is considered ready.
+    const bool ready_now = depth_ready || has_cloud_obs;
 
     if (ready_now)
     {
@@ -754,8 +786,8 @@ namespace ego_planner
     if (debug_fsm_)
     {
       ROS_INFO_THROTTLE(debug_fsm_interval_,
-                        "[FSM] map_ready=%d inflated=%d cloud=%zu depth=%d hold=%.1f/%.1f",
-                        ready, inflated, cloud_pts, has_depth,
+                        "[FSM] map_ready=%d inflated=%d cloud=%zu cloud_ready=%d depth=%d cloud_obs=%d hold=%.1f/%.1f",
+                        ready, inflated, cloud_pts, cloud_ready, has_depth, has_cloud_obs,
                         map_ready_start_time_.isZero() ? 0.0 : (ros::Time::now() - map_ready_start_time_).toSec(),
                         map_ready_hold_time_);
     }
@@ -783,6 +815,12 @@ namespace ego_planner
           ROS_INFO_THROTTLE(debug_fsm_interval_, "[FSM] planFromGlobalTraj success trial=%d", i + 1);
         return true;
       }
+      if (planner_manager_->isLastReplanFailedForTerminalInObstacle())
+      {
+        if (debug_fsm_)
+          ROS_WARN_THROTTLE(debug_fsm_interval_, "[FSM] planFromGlobalTraj abort: target in obstacle");
+        return false;
+      }
     }
     if (debug_fsm_)
       ROS_WARN_THROTTLE(debug_fsm_interval_, "[FSM] planFromGlobalTraj failed trials=%d", trial_times);
@@ -806,13 +844,33 @@ namespace ego_planner
 
     if (!success)
     {
+      if (planner_manager_->isLastReplanFailedForTerminalInObstacle())
+      {
+        if (debug_fsm_)
+          ROS_WARN_THROTTLE(debug_fsm_interval_, "[FSM] planFromCurrentTraj abort: target in obstacle");
+        return false;
+      }
+
       success = callReboundReplan(true, false);
       //changeFSMExecState(EXEC_TRAJ, "FSM");
       if (!success)
       {
+        if (planner_manager_->isLastReplanFailedForTerminalInObstacle())
+        {
+          if (debug_fsm_)
+            ROS_WARN_THROTTLE(debug_fsm_interval_, "[FSM] planFromCurrentTraj abort: target in obstacle");
+          return false;
+        }
+
         for (int i = 0; i < trial_times; i++)
         {
           success = callReboundReplan(true, true);
+          if (!success && planner_manager_->isLastReplanFailedForTerminalInObstacle())
+          {
+            if (debug_fsm_)
+              ROS_WARN_THROTTLE(debug_fsm_interval_, "[FSM] planFromCurrentTraj abort in random retry: target in obstacle");
+            return false;
+          }
           if (success)
             break;
         }

--- a/planner/ego_planner_swarm/plan_manage/src/planner_manager.cpp
+++ b/planner/ego_planner_swarm/plan_manage/src/planner_manager.cpp
@@ -80,6 +80,8 @@ namespace ego_planner
     if (debug_planner_)
       ROS_INFO_THROTTLE(debug_planner_interval_, "[planner] replan start dist=%.3f failures=%d", (start_pt - local_target_pt).norm(), continous_failures_count_);
 
+    last_replan_terminal_in_obstacle_ = false;
+
     bspline_optimizer_->setLocalTargetPt(local_target_pt);
 
     ros::Time t_start = ros::Time::now();
@@ -277,6 +279,8 @@ namespace ego_planner
         }
         else
         {
+          last_replan_terminal_in_obstacle_ =
+              last_replan_terminal_in_obstacle_ || bspline_optimizer_->isTerminalInObstacleAbort();
           cout << "traj " << trajs.size() - i << " failed." << endl;
         }
       }
@@ -288,6 +292,7 @@ namespace ego_planner
     else
     {
       flag_step_1_success = bspline_optimizer_->BsplineOptimizeTrajRebound(ctrl_pts, ts);
+      last_replan_terminal_in_obstacle_ = bspline_optimizer_->isTerminalInObstacleAbort();
       t_opt = ros::Time::now() - t_start;
       //static int vis_id = 0;
       visualization_->displayInitPathList(point_set, 0.2, 0);
@@ -353,6 +358,7 @@ namespace ego_planner
 
     // success. YoY
     continous_failures_count_ = 0;
+    last_replan_terminal_in_obstacle_ = false;
     if (debug_planner_)
       ROS_INFO_THROTTLE(debug_planner_interval_, "[planner] replan success time=%.3f", (t_init + t_opt + t_refine).toSec());
     return true;


### PR DESCRIPTION
…-blocked targets

- Modify map-ready check logic to prioritize observation availability (depth or cloud) over inflated voxel count, preventing planning blocks in low-density environments.
- Implement specialized handling for targets located within obstacles: the planner now aborts the current session and resets to WAIT_TARGET state instead of attempting invalid fallbacks.
- Optimize terminal point collision detection in BsplineOptimizer to trigger early abort and state machine recovery.
- Reduce logging frequency for inflated voxels and track point cloud observation status.
- Fix various bugs in launch files and point cloud processing scripts.